### PR TITLE
Add hidden NFC contact page

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,6 +12,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-gray-200 dark:bg-gray-900 text-black dark:text-white">
     <head>
         <Meta title={`${frontmatter.title} | Nebula's Blog`} description={frontmatter.description} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -15,6 +15,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-gray-200 dark:bg-gray-900 text-black dark:text-white">
     <head>
         <Meta title={title || "DisPaisy"} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/layouts/Light.astro
+++ b/src/layouts/Light.astro
@@ -15,6 +15,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-white text-black">
     <head>
         <Meta title={title || "DisPaisy"} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/pages/stolenorfotgot/devices.astro
+++ b/src/pages/stolenorfotgot/devices.astro
@@ -1,0 +1,29 @@
+---
+import Layout from '@layouts/Default.astro';
+---
+
+<meta slot="head" name="robots" content="noindex,nofollow" />
+<script>
+    const switchToIt = () => {
+        document.getElementById('lang-en').classList.add('hidden');
+        document.getElementById('lang-it').classList.remove('hidden');
+    };
+    const switchToEn = () => {
+        document.getElementById('lang-it').classList.add('hidden');
+        document.getElementById('lang-en').classList.remove('hidden');
+    };
+</script>
+
+<Layout title="Lost or Stolen Device">
+    <div class="prose dark:prose-dark">
+        <h1>Lost or Stolen Device</h1>
+        <div id="lang-en">
+            <p>If you have found this device, please contact me at <a href="mailto:dis@paisy.lol">dis@paisy.lol</a> or WhatsApp <a href="https://wa.me/393509683948">+393509683948</a>.</p>
+            <button onclick="switchToIt()" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Italiano</button>
+        </div>
+        <div id="lang-it" class="hidden">
+            <p>Se hai trovato questo dispositivo, contattami via email a <a href="mailto:dis@paisy.lol">dis@paisy.lol</a> oppure su WhatsApp <a href="https://wa.me/393509683948">+393509683948</a>.</p>
+            <button onclick="switchToEn()" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">English</button>
+        </div>
+    </div>
+</Layout>


### PR DESCRIPTION
## Summary
- create `/stolenorfotgot/devices` page with EN/IT switch and contact details
- allow passing custom head content in layouts

## Testing
- `npm run build` *(fails: astro not found)*